### PR TITLE
Removed double quote typo

### DIFF
--- a/client-and-server/server/php/public/index.html
+++ b/client-and-server/server/php/public/index.html
@@ -48,7 +48,7 @@
           <button
             id="submit"
             data-i18n="button.submit"
-            i18n-options='{ "total": "0" }"'
+            i18n-options='{ "total": "0" }'
           ></button>
         </section>
         <div id="error-message"></div>


### PR DESCRIPTION
If you set up this sample but don't provide a Price ID in `config.ini`, we default to the contents of `i18n-options`. Because of the extra `"` the JSON fails to parse and blows up at https://github.com/stripe-samples/checkout-one-time-payments/blob/master/client-and-server/server/php/public/translation.js#L34

Interestingly the extra `"` isn't there in https://github.com/stripe-samples/checkout-one-time-payments/blob/master/client-and-server/client/html/index.html#L51 so this might be a PHP only bug.