### PR TITLE
Parity for viewport meta tag with index.html in pure html/js client 

### DIFF
--- a/client/html/canceled.html
+++ b/client/html/canceled.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Stripe Checkout Sample</title>
     <meta name="description" content="A demo of Stripe Payment Intents" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="css/normalize.css" />

--- a/client/html/success.html
+++ b/client/html/success.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Stripe Checkout Sample</title>
     <meta name="description" content="A demo of Stripe Payment Intents" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="css/normalize.css" />


### PR DESCRIPTION
This PR achieve parity for viewport meta tag with `index.html` in pure html/js client for `success.html` and `canceled.html` pages.