### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,15 @@ jobs:
           STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
           PRICE: price_1Hf3k8CWW2eVYDoPDT6y9NLt
+
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose logs web
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
+          BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # repository: 'stripe-samples/checkout-one-time-payments'
-          repository: 'hibariya/checkout-one-time-payments'
-          ref: 'ci'
+          repository: 'stripe-samples/checkout-one-time-payments'
 
       - uses: actions/checkout@v2
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'ci'
 
       - name: Install gettext for envsubst
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI for stripe-samples/checkout-one-time-payments
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # repository: 'stripe-samples/checkout-one-time-payments'
+          repository: 'hibariya/checkout-one-time-payments'
+          ref: 'ci'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+          ref: 'ci'
+
+      - name: Install gettext for envsubst
+        run: |
+          sudo apt install gettext-base
+
+      - name: Install jq
+        run: |
+          sudo curl -o /usr/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          sudo chmod +x /usr/bin/jq
+
+      - name: Run tests
+        run: |
+          source sample-ci/helpers.sh
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=http://web:4242
+          PRICE=${PRICE}
+          PAYMENT_METHODS="card"
+          EOF
+
+          for lang in $(cat .cli.json | server_langs_for_integration main)
+          do
+            [ "$lang" = "php" ] && continue
+
+            configure_docker_compose_for_integration . "$lang" ../../client/html \
+                                                     target/single-product-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+            docker-compose up -d && wait_web_server
+            docker-compose exec -T runner bundle exec rspec spec/client_and_server_spec.rb
+          done
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PRICE: price_1Hf3k8CWW2eVYDoPDT6y9NLt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'rspec'
+gem 'rest-client'
+gem 'byebug'
+gem 'stripe'

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -32,8 +32,8 @@ func main() {
 	http.HandleFunc("/create-checkout-session", handleCreateCheckoutSession)
 	http.HandleFunc("/webhook", handleWebhook)
 
-	log.Println("server running at localhost:4242")
-	http.ListenAndServe("localhost:4242", nil)
+	log.Println("server running at 0.0.0.0:4242")
+	http.ListenAndServe("0.0.0.0:4242", nil)
 }
 
 // ErrorResponseMessage represents the structure of the error

--- a/server/php-slim/composer.json
+++ b/server/php-slim/composer.json
@@ -6,6 +6,6 @@
     "monolog/monolog": "^1.17"
   },
   "scripts": {
-    "start": "php -S localhost:4242 index.php"
+    "start": "php -S 0.0.0.0:4242 index.php"
   }
 }

--- a/server/php/composer.json
+++ b/server/php/composer.json
@@ -1,5 +1,8 @@
 {
   "require": {
     "stripe/stripe-php": "^7.31.0"
+  },
+  "scripts": {
+    "start": "php -S 0.0.0.0:4242"
   }
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
 =end
 end
 
-SERVER_URL = "http://localhost:4242"
+SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 
 def get(path, *args, **kwargs)
   RestClient.get("#{SERVER_URL}#{path}", *args, **kwargs)


### PR DESCRIPTION
This is similar to https://github.com/stripe-samples/subscription-use-cases/pull/65. I added CI settings that ensure all server implementation can boot or pass existing tests. I also made some changes to run apps on Docker containers. You can confirm that a result of the workflow [here](https://github.com/hibariya/checkout-one-time-payments/runs/1417743383?check_suite_focus=true).

Note that this PR needs the following PRs to be merged.

* https://github.com/stripe-samples/sample-ci/pull/1