### PR TITLE
Use the same name to let CI run without passing the jar file path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI for stripe-samples/checkout-one-time-payments
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI for stripe-samples/checkout-one-time-payments
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          repository: 'stripe-samples/checkout-one-time-payments'
 
       - uses: actions/checkout@v2
         with:
@@ -39,8 +37,7 @@ jobs:
           do
             [ "$lang" = "php" ] && continue
 
-            configure_docker_compose_for_integration . "$lang" ../../client/html \
-                                                     target/single-product-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+            configure_docker_compose_for_integration . "$lang" ../../client/html
 
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/client_and_server_spec.rb

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -32,7 +32,7 @@ mvn package
 2. Run the packaged jar
 
 ```
-java -cp target/single-product-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 4. If you're using the html client, go to `localhost:4242` to see the demo. For

--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As described in https://github.com/stripe-samples/sample-ci/pull/2, I changed the jar file names to the same one. 
