### PR TITLE
Only run on push events to master branches by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI for stripe-samples/checkout-one-time-payments
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
to avoid unintended CI runs on forked repositories as much as possible.
Related issue: stripe-samples/sample-ci#4