### PR TITLE
Add e2e tests for client/react-cra and client/html

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           echo '--format RSpec::Github::Formatter --format progress' >> .rspec
 
       - name: Run tests for client/html
+        if: ${{ always() }}
         env:
           SERVER_URL: http://web:4242
         run: |
@@ -98,6 +99,7 @@ jobs:
           docker-compose exec -T runner bundle exec rspec spec/e2e_spec.rb
 
       - name: Run tests for client/react-cra
+        if: ${{ always() }}
         env:
           SERVER_URL: http://frontend:3000
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,13 @@ on:
     branches:
       - master
 
+env:
+  STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+  STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+  PRICE: ${{ secrets.TEST_PRICE }}
+
 jobs:
-  test:
+  server_test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +25,10 @@ jobs:
           source sample-ci/helpers.sh
 
           setup_dependencies
+
+      - name: Prepare tests
+        run: |
+          echo '--format RSpec::Github::Formatter --format progress' >> .rspec
 
       - name: Run tests
         run: |
@@ -42,10 +51,6 @@ jobs:
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/client_and_server_spec.rb
           done
-        env:
-          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
-          PRICE: ${{ secrets.TEST_PRICE }}
 
       - name: Collect debug information
         if: ${{ failure() }}
@@ -53,3 +58,78 @@ jobs:
           cat docker-compose.yml
           docker-compose ps -a
           docker-compose logs web
+
+  e2e_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+
+      - name: Setup dependencies
+        run: |
+          source sample-ci/helpers.sh
+
+          setup_dependencies
+
+      - name: Prepare tests
+        run: |
+          echo '--format RSpec::Github::Formatter --format progress' >> .rspec
+
+      - name: Run tests for client/html
+        env:
+          SERVER_URL: http://web:4242
+        run: |
+          source sample-ci/helpers.sh
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          PRICE=${PRICE}
+          PAYMENT_METHOD_TYPES="card,ideal"
+          EOF
+
+          configure_docker_compose_for_integration . node ../../client/html
+          docker-compose --profile=e2e up -d && wait_web_server
+          docker-compose exec -T runner bundle exec rspec spec/e2e_spec.rb
+
+      - name: Run tests for client/react-cra
+        env:
+          SERVER_URL: http://frontend:3000
+        run: |
+          source sample-ci/helpers.sh
+
+          echo "$(cat client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > client/react-cra/package.json
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          PRICE=${PRICE}
+          PAYMENT_METHOD_TYPES="card,ideal"
+          EOF
+
+          configure_docker_compose_for_integration . node ../../client/react-cra
+          docker-compose --profile=frontend up -d && wait_web_server
+          docker-compose exec -T runner bundle exec rspec spec/e2e_spec.rb
+
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose --profile=frontend logs web
+
+          docker cp $(docker-compose ps -qa runner | head -1):/work/tmp .
+
+      - name: Upload capybara screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: |
+            tmp/capybara

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ gem 'rspec'
 gem 'rest-client'
 gem 'byebug'
 gem 'stripe'
+
+gem 'selenium-webdriver'
+gem 'capybara'
+gem 'capybara-screenshot'
+
+gem 'rspec-github', require: false

--- a/spec/capybara_support.rb
+++ b/spec/capybara_support.rb
@@ -1,0 +1,34 @@
+require 'capybara/rspec'
+require 'selenium-webdriver'
+require 'capybara-screenshot/rspec'
+
+Capybara.server_host = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
+
+Capybara.register_driver :chrome do |app|
+  opts = {browser: :chrome, url: ENV.fetch('SELENIUM_URL', 'http://selenium:4444/wd/hub')}
+  Capybara::Selenium::Driver.new(app, **opts)
+end
+
+Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+Capybara.javascript_driver = :chrome
+Capybara.default_driver = :chrome
+Capybara.default_max_wait_time = 20
+Capybara.enable_aria_label = true
+Capybara.save_path = 'tmp/capybara'
+
+module CapybaraHelpers
+  SERVER_URL = ENV.fetch('SERVER_URL', 'http://web:4242')
+
+  def server_url(path)
+    url = URI(SERVER_URL)
+    url.path = path
+    url
+  end
+end
+
+RSpec.configure do |config|
+  config.include CapybaraHelpers
+end

--- a/spec/e2e_spec.rb
+++ b/spec/e2e_spec.rb
@@ -1,0 +1,33 @@
+require 'capybara_support'
+
+RSpec.describe "Checkout one-time payments", type: :system do
+  example "With a valid card, the payment should be completed successfully" do
+    visit server_url('/')
+
+    click_on '+'
+    click_on 'Buy'
+
+    fill_in 'email', with: 'test@example.com'
+    click_on 'Pay with card'
+    fill_in 'cardNumber', with: '4242424242424242'
+    fill_in 'cardExpiry', with: '12 / 33'
+    fill_in 'CVC', with: '123'
+    fill_in 'billingName', with: 'James McGill'
+    select 'United States', from: 'billingCountry'
+    fill_in 'billingPostalCode', with: '10000'
+
+    click_on 'Pay €20.00'
+
+    expect(page).to have_content 'Your payment succeeded'
+    expect(page).to have_content '"amount_total": 2000'
+  end
+
+  example "Cancel a payment" do
+    visit server_url('/')
+
+    click_on 'Buy'
+    click_on 'Previous page'
+
+    expect(page).to have_content 'Your payment was canceled'
+  end
+end


### PR DESCRIPTION
:memo: This needs https://github.com/stripe-samples/sample-ci/pull/12.

I added e2e tests to test the app through client/html and client/react-cra. Most capybara settings are similar to https://github.com/stripe-samples/accept-a-card-payment/pull/54.

I also added capybara-screenshot and rspec-github. capybara-screenshot takes screenshots of the browser if the e2e tests failed.  We can download them as the artifacts of CI. Using rspec-github on CI we can have a glance of failure on the summary page like this: https://github.com/hibariya/checkout-one-time-payments/actions/runs/856535240.

I had to modify `client/react-cra/package.json` to change the proxy destination from `localhost` to `web`. It looks a little awkward. Happy to fix it if there is a better way.