### PR TITLE
Include Stripe Tax Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=dem
 
   Before creating a price, make sure you have Stripe Tax set up in the dashboard: [Docs - Set up Stripe Tax](https://stripe.com/docs/tax/set-up).
 
-  Stripe needs to know what kind of product you are selling to calculate the taxes. For this example we will submit a tax code describing what kind of product is used: `txcd_99999999` which is 'General - Tangible Goods'. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). If you leave the tax code empty, Stripe will use the default one from your [Tax settings](https://dashboard.stripe.com/test/settings/tax).
+  Stripe needs to know what kind of product you are selling to calculate the taxes. For this example we will submit a tax code describing what kind of product is used: `txcd_10000000` which is 'General - Electronically Supplied Services'. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). If you leave the tax code empty, Stripe will use the default one from your [Tax settings](https://dashboard.stripe.com/test/settings/tax).
 
   ```sh
   stripe products create \
     --name="demo" \
-    --tax-code="txcd_99999999"
+    --tax-code="txcd_10000000"
   ```
 
   From the response, copy the `id` and create a price. The tax behavior can be either `inclusive` or `exclusive`. For our example, we are using `exclusive`.

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=dem
 
 <details>
 <summary>With Stripe Tax</summary>
+  Stripe Tax lets you calculate and collect sales tax, VAT and GST with one line of code.
 
   Before creating a price, make sure you have Stripe Tax set up in the dashboard: [Docs - Set up Stripe Tax](https://stripe.com/docs/tax/set-up).
 
-  Because Stripe needs to know what kind of product you are selling, you need to submit a valid tax code specifying what kind of product you are selling. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). In this example, we will use `txcd_99999999` which is 'General - Tangible Goods'.
+  Stripe needs to know what kind of product you are selling to calculate the taxes. For this example we will submit a tax code describing what kind of product is used: `txcd_99999999` which is 'General - Tangible Goods'. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). If you leave the tax code empty, Stripe will use the default one from your [Tax settings](https://dashboard.stripe.com/test/settings/tax).
 
   ```sh
   stripe products create \
@@ -127,7 +128,7 @@ stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=dem
     --tax-code="txcd_99999999"
   ```
 
-  From the response, copy the `id` and create a price. The tax behavior can be either `inclusive`, `exclusive` or `unspecified`. For our example, we are using `exclusive`.
+  From the response, copy the `id` and create a price. The tax behavior can be either `inclusive` or `exclusive`. For our example, we are using `exclusive`.
 
   ```sh
   stripe prices create \
@@ -179,7 +180,7 @@ For example, if you want to run the Node server:
 
 ```
 cd server/node 
-# There's a README in this folder with instructions + a how to enable Stripe Tax.
+# There's a README in this folder with instructions to run the server and how to enable Stripe Tax.
 npm install
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -114,11 +114,27 @@ You can quickly create a Price with the Stripe CLI like so:
 stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=demo"
 ```
 
-<details open>
+<details>
 <summary>With Stripe Tax</summary>
 
+  Before creating a price, make sure you have Stripe Tax set up in the dashboard: [Docs - Set up Stripe Tax](https://stripe.com/docs/tax/set-up).
+
+  Because Stripe needs to know what kind of product you are selling, you need to submit a valid tax code specifying what kind of product you are selling. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). In this example, we will use `txcd_99999999` which is 'General - Tangible Goods'.
+
   ```sh
-  stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=demo" -d "automatic_tax[enabled]"="true"
+  stripe products create \
+    --name="demo" \
+    --tax-code="txcd_99999999"
+  ```
+
+  From the response, copy the `id` and create a price. The tax behavior can be either `inclusive`, `exclusive` or `unspecified`. For our example, we are using `exclusive`.
+
+  ```sh
+  stripe prices create \
+    --unit-amount=500 \
+    --currency=usd \
+    --tax-behavior=exclusive \
+    --product=<INSERT_ID, like prod_ABC123>
   ```
 
   More Information: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
@@ -162,7 +178,8 @@ Pick the server language you want and follow the instructions in the server fold
 For example, if you want to run the Node server:
 
 ```
-cd server/node # there's a README in this folder with instructions
+cd server/node 
+# There's a README in this folder with instructions + a how to enable Stripe Tax.
 npm install
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ You can quickly create a Price with the Stripe CLI like so:
 stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=demo"
 ```
 
+<details open>
+<summary>With Stripe Tax</summary>
+
+  ```sh
+  stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=demo" -d "automatic_tax[enabled]"="true"
+  ```
+
+  More Information: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 Which will return the json:
 
 ```json

--- a/server/dotnet/Controllers/PaymentsController.cs
+++ b/server/dotnet/Controllers/PaymentsController.cs
@@ -57,7 +57,7 @@ namespace server.Controllers
             //  [billing_address_collection] - to display billing address details on the page
             //  [customer] - if you have an existing Stripe Customer ID
             //  [customer_email] - lets you prefill the email input in the form
-            //  [automatic_tax] - to automatically calculate consumer tax in the Checkout page
+            //  [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
             //  For full details see https:#stripe.com/docs/api/checkout/sessions/create
 
             //  ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param

--- a/server/dotnet/Controllers/PaymentsController.cs
+++ b/server/dotnet/Controllers/PaymentsController.cs
@@ -57,6 +57,7 @@ namespace server.Controllers
             //  [billing_address_collection] - to display billing address details on the page
             //  [customer] - if you have an existing Stripe Customer ID
             //  [customer_email] - lets you prefill the email input in the form
+            //  [automatic_tax] - to automatically calculate consumer tax in the Checkout page
             //  For full details see https:#stripe.com/docs/api/checkout/sessions/create
 
             //  ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
@@ -74,6 +75,7 @@ namespace server.Controllers
                         Price = this.options.Value.Price,
                     },
                 },
+                // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
             };
 
             var service = new SessionService(this.client);

--- a/server/dotnet/README.md
+++ b/server/dotnet/README.md
@@ -24,6 +24,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Controllers/PaymentsController.cs`](./Controllers/PaymentsController.cs) file you will find the following code commented out
+   ```csharp
+   // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Run the application
 
 ```

--- a/server/dotnet/README.md
+++ b/server/dotnet/README.md
@@ -34,7 +34,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Run the application

--- a/server/go/README.md
+++ b/server/go/README.md
@@ -32,7 +32,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Install dependencies

--- a/server/go/README.md
+++ b/server/go/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.go`](./server.go) file you will find the following code commented out
+   ```go
+   // AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 
 ```

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -107,6 +107,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 	// [customer] - if you have an existing Stripe Customer ID
 	// [payment_intent_data] - lets capture the payment later
 	// [customer_email] - lets you prefill the email input in the form
+	// [automatic_tax] - to automatically calculate consumer tax in the checkout page
 	// For full details see https://stripe.com/docs/api/checkout/sessions/create
 
 	// ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID
@@ -122,6 +123,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 				Price:    stripe.String(os.Getenv("PRICE")),
 			},
 		},
+		// AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
 	}
 	s, err := session.New(params)
 	if err != nil {

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -107,7 +107,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 	// [customer] - if you have an existing Stripe Customer ID
 	// [payment_intent_data] - lets capture the payment later
 	// [customer_email] - lets you prefill the email input in the form
-	// [automatic_tax] - to automatically calculate consumer tax in the checkout page
+	// [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
 	// For full details see https://stripe.com/docs/api/checkout/sessions/create
 
 	// ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -23,6 +23,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Server.java`](./src/main/java/com/stripe/sample/Server.java) file you will find the following code commented out
+   ```java
+   // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build())
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 
 2. Build the jar
 

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -33,7 +33,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -98,7 +98,7 @@ public class Server {
             // [billing_address_collection] - to display billing address details on the page
             // [customer] - if you have an existing Stripe Customer ID
             // [customer_email] - lets you prefill the email input in the form
-            // [automatic_tax] - to automatically calculate consumer tax in the checkout page
+            // [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
             // For full details see https://stripe.com/docs/api/checkout/sessions/create
 
             // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -98,6 +98,7 @@ public class Server {
             // [billing_address_collection] - to display billing address details on the page
             // [customer] - if you have an existing Stripe Customer ID
             // [customer_email] - lets you prefill the email input in the form
+            // [automatic_tax] - to automatically calculate consumer tax in the checkout page
             // For full details see https://stripe.com/docs/api/checkout/sessions/create
 
             // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID
@@ -106,6 +107,7 @@ public class Server {
                     .setSuccessUrl(domainUrl + "/success.html?session_id={CHECKOUT_SESSION_ID}")
                     .setCancelUrl(domainUrl + "/canceled.html")
                     .addAllPaymentMethodType(paymentMethodTypes)
+                    // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build())
                     .setMode(SessionCreateParams.Mode.PAYMENT);
 
             // Add a line item for the sticker the Customer is purchasing

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -32,7 +32,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Install dependencies

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.js`](./server.js) file you will find the following code commented out
+   ```js
+   // automatic_tax: {enabled: true},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 
 ```

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -81,6 +81,7 @@ app.post('/create-checkout-session', async (req, res) => {
     // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
     success_url: `${domainURL}/success.html?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${domainURL}/canceled.html`,
+    // automatic_tax: {enabled: true},
   });
 
   return res.redirect(303, session.url);

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -68,7 +68,7 @@ app.post('/create-checkout-session', async (req, res) => {
   // [billing_address_collection] - to display billing address details on the page
   // [customer] - if you have an existing Stripe Customer ID
   // [customer_email] - lets you prefill the email input in the Checkout page
-  // [automatic_tax] - to automatically calculate consumer tax in the Checkout page
+  // [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
   // For full details see https://stripe.com/docs/api/checkout/sessions/create
   const session = await stripe.checkout.sessions.create({
     payment_method_types: pmTypes,

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -68,6 +68,7 @@ app.post('/create-checkout-session', async (req, res) => {
   // [billing_address_collection] - to display billing address details on the page
   // [customer] - if you have an existing Stripe Customer ID
   // [customer_email] - lets you prefill the email input in the Checkout page
+  // [automatic_tax] - to automatically calculate consumer tax in the Checkout page
   // For full details see https://stripe.com/docs/api/checkout/sessions/create
   const session = await stripe.checkout.sessions.create({
     payment_method_types: pmTypes,

--- a/server/php/README.md
+++ b/server/php/README.md
@@ -28,6 +28,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`create-checkout-session.php`](./public/create-checkout-session.php) file you will find the following code commented out
+   ```php
+   // 'automatic_tax' => ['enabled' => true],
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Run composer to set up dependencies
 
 ```

--- a/server/php/README.md
+++ b/server/php/README.md
@@ -38,7 +38,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Run composer to set up dependencies

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -34,7 +34,7 @@ $quantity = $_POST['quantity'];
 // [billing_address_collection] - to display billing address details on the page
 // [customer] - if you have an existing Stripe Customer ID
 // [customer_email] - lets you prefill the email input in the form
-// [automatic_tax] - to automatically calculate consumer tax in the checkout page
+// [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
 // For full details see https://stripe.com/docs/api/checkout/sessions/create
 // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
 $checkout_session = \Stripe\Checkout\Session::create([

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -34,6 +34,7 @@ $quantity = $_POST['quantity'];
 // [billing_address_collection] - to display billing address details on the page
 // [customer] - if you have an existing Stripe Customer ID
 // [customer_email] - lets you prefill the email input in the form
+// [automatic_tax] - to automatically calculate consumer tax in the checkout page
 // For full details see https://stripe.com/docs/api/checkout/sessions/create
 // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
 $checkout_session = \Stripe\Checkout\Session::create([
@@ -41,6 +42,7 @@ $checkout_session = \Stripe\Checkout\Session::create([
   'cancel_url' => $domain_url . '/canceled.html',
   'payment_method_types' => explode(",", $_ENV['PAYMENT_METHOD_TYPES']),
   'mode' => 'payment',
+  // 'automatic_tax' => ['enabled' => true],
   'line_items' => [[
     'price' => $price,
     'quantity' => $quantity,

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -32,7 +32,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Create and activate a new virtual environment

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.py`](./server.py) file you will find the following code commented out
+   ```python
+   # automatic_tax={'enabled': True},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Create and activate a new virtual environment
 
 **MacOS / Unix**

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -71,6 +71,7 @@ def create_checkout_session():
         # [customer] - if you have an existing Stripe Customer ID
         # [payment_intent_data] - lets capture the payment later
         # [customer_email] - lets you prefill the email input in the form
+        # [automatic_tax] - to automatically calculate consumer tax in the checkout page
         # For full details see https:#stripe.com/docs/api/checkout/sessions/create
 
         # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
@@ -79,6 +80,7 @@ def create_checkout_session():
             cancel_url=domain_url + '/canceled.html',
             payment_method_types= os.getenv('PAYMENT_METHOD_TYPES').split(','),
             mode='payment',
+            # automatic_tax={'enabled': True},
             line_items=[{
                 'price': os.getenv('PRICE'),
                 'quantity': quantity,

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -71,7 +71,7 @@ def create_checkout_session():
         # [customer] - if you have an existing Stripe Customer ID
         # [payment_intent_data] - lets capture the payment later
         # [customer_email] - lets you prefill the email input in the form
-        # [automatic_tax] - to automatically calculate consumer tax in the checkout page
+        # [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
         # For full details see https:#stripe.com/docs/api/checkout/sessions/create
 
         # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param

--- a/server/ruby/README.md
+++ b/server/ruby/README.md
@@ -33,7 +33,7 @@ from the dashboard or with the Stripe CLI.
 
    Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
 
-   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
 </details>
 
 2. Install dependencies

--- a/server/ruby/README.md
+++ b/server/ruby/README.md
@@ -23,6 +23,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.rb`](./server.rb) file you will find the following code commented out
+   ```ruby
+   # automatic_tax: { enabled: true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products & prices updated with tax codes and tax behavior: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 ```
 bundle install

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -64,6 +64,7 @@ post '/create-checkout-session' do
   # [billing_address_collection] - to display billing address details on the page
   # [customer] - if you have an existing Stripe Customer ID
   # [customer_email] - lets you prefill the email input in the form
+  # [automatic_tax] - to automatically calculate consumer tax in the checkout page
   # For full details see https:#stripe.com/docs/api/checkout/sessions/create
   # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
   session = Stripe::Checkout::Session.create(
@@ -71,6 +72,7 @@ post '/create-checkout-session' do
     cancel_url: ENV['DOMAIN'] + '/canceled.html',
     payment_method_types: pm_types,
     mode: 'payment',
+    # automatic_tax: { enabled: true },
     line_items: [{
       quantity: params['quantity'],
       price: ENV['PRICE'],

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -64,7 +64,7 @@ post '/create-checkout-session' do
   # [billing_address_collection] - to display billing address details on the page
   # [customer] - if you have an existing Stripe Customer ID
   # [customer_email] - lets you prefill the email input in the form
-  # [automatic_tax] - to automatically calculate consumer tax in the checkout page
+  # [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
   # For full details see https:#stripe.com/docs/api/checkout/sessions/create
   # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
   session = Stripe::Checkout::Session.create(


### PR DESCRIPTION
## Summary

I have included how customers can use Stripe Tax to automatically collect taxes in their checkout.

- Updated the `README.md` with the general set up flow, hidden below a dropdown. It explains how to create products and prices with additional properties that are needed for the automatic tax collection.
- Updated the `README.md` under each server's directory to showcase what has to be done to include Stripe Tax (simply uncomment a line of code)
- Wrote the line of code to enable Stripe Tax for each language's server and uncommented the line, so customers can enable it in an easy way

## Testing

I have tested each example manually and tax was shown when the line of code was uncommented.
## General

Thanks for using an `.env` file. It made testing a breeze 👍 

Another question: Do you think I should include a `.gif` on how the checkout looks with Stripe Tax enabled?

## Open Tasks

- [x] "Because Stripe needs to know what kind of product you are selling, you need to submit a valid tax code specifying what kind of product you are selling." --> Restructure to not mention "you are selling" twice
- [x] "The tax behavior can be either `inclusive`, `exclusive` or `unspecified`." - What does `unspecified` mean?
- [x] "There's a README in this folder with instructions + a how to enable Stripe Tax" --> "There's a README in this folder with instructions to run the server and how to enable Stripe Tax"
- [x] "products & prices" --> "products and prices"
- [x] Change tax code to "electronically supplied services"