### PR TITLE
Add CONTRIBUTING.md and code of conduct files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at conduct@stripe.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to this Checkout sample
+
+Thanks for contributing to this sample!
+
+## Issues
+
+This sample shows you how to integrate with [Stripe Checkout](https://stripe.com/docs/payments/checkout). Please only file issues here that you believe represent bugs with this particular sample, not Stripe Checkout or the [Stripe CLI](https://stripe.com/docs/stripe-cli) itself.
+
+If you're having general trouble with Checkout, please reach out to us using the form at <https://support.stripe.com/email>, or come chat with us on the [Stripe Discord server](https://discord.com/invite/rujnsbxrqn). We're very proud of our level of service, and we're more than happy to help you out with your integration.
+
+If you've found a bug in any of the implementations in this repository, please [let us know](https://github.com/stripe-samples/checkout-one-time-payments/issues/new)!
+
+## Code review
+
+All pull requests will be reviewed by someone from Stripe before merging. At
+Stripe, we believe that code review is for explaining and having a discussion
+around code. For those new to code review, we strongly recommend [this
+video](https://www.youtube.com/watch?v=pjjmw9trb7s) on "code review culture."
+
+## Developing
+
+This sample includes 8 server implementations so, to run locally, follow the steps indicated in the [main README.md](README.md#how-to-run-locally), followed with the instructions in the README of the server implemtation of your choice.


### PR DESCRIPTION
Related to #45, I worked on adding a CONTRIBUTING.md file, inspired by what I found on the [react-stripe-js repo](https://github.com/stripe/react-stripe-js/blob/master/CONTRIBUTING.md). 