### PR TITLE
Update dotnet to 6.0

### DIFF
--- a/server/dotnet/server.csproj
+++ b/server/dotnet/server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
 


### PR DESCRIPTION
This PR updates the version of .NET from 3.1 to 6.0 to stay up to date with a more recent version