### PR TITLE
Update dependabot schedule day to thursday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,39 +10,46 @@ updates:
     directory: "/server/ruby/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # python dependencies
   - package-ecosystem: "pip"
     directory: "/server/python/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # php dependencies
   - package-ecosystem: "composer"
     directory: "/server/php/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # node dependencies
   - package-ecosystem: "npm"
     directory: "/server/node/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # go dependencies
   - package-ecosystem: "gomod"
     directory: "/server/go/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # java dependencies
   - package-ecosystem: "maven"
     directory: "/server/java/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # dotnet dependencies
   - package-ecosystem: "nuget"
     directory: "/server/dotnet/"
     schedule:
       interval: "weekly"
+      day: "thursday"


### PR DESCRIPTION
To make dependencies updates more manageable, I am updating the samples' update day to Thursday so we can try to make it a weekly task on Fridays