### PR TITLE
Fix /create-checkout-session to return 303 (.Net sample)

### DIFF
--- a/server/dotnet/Program.cs
+++ b/server/dotnet/Program.cs
@@ -79,7 +79,8 @@ app.MapPost("/create-checkout-session", async (IOptions<StripeOptions> stripeOpt
 
     var service = new SessionService();
     var session = await service.CreateAsync(options);
-    return Results.Redirect(session.Url);
+    context.Response.Headers.Add("Location", session.Url);
+    return Results.StatusCode(303);
 });
 
 app.MapPost("webhook", async (IOptions<StripeOptions> stripeOptions, HttpContext context) =>


### PR DESCRIPTION
The spec expects it to return 303, but Results.Redirect returns 302.
This should fix the errors on CI: https://github.com/stripe-samples/checkout-one-time-payments/runs/8044844078?check_suite_focus=true