### PR TITLE
Open Dependabot PRs only for minor or major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # python dependencies
   - package-ecosystem: "pip"
@@ -18,6 +21,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # php dependencies
   - package-ecosystem: "composer"
@@ -25,6 +31,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # node dependencies
   - package-ecosystem: "npm"
@@ -32,6 +41,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # go dependencies
   - package-ecosystem: "gomod"
@@ -39,6 +51,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # java dependencies
   - package-ecosystem: "maven"
@@ -46,6 +61,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # dotnet dependencies
   - package-ecosystem: "nuget"
@@ -53,3 +71,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Same as https://github.com/stripe-samples/accept-a-payment/pull/2048, this makes Dependabot ignore patch-version updates. To allow security updates (like https://github.com/hibariya/accept-a-payment/pull/1749), I recommend enabling Dependabot security updates on the repository settings if we haven't enabled it yet.