### PR TITLE
Fix CI: Tests need changed_files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
 
   server_test:
     runs-on: ubuntu-latest
+    needs: changed_files
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Sorry, I made a mistake in https://github.com/stripe-samples/checkout-one-time-payments/pull/563 🙏 
`server_test` needs `changed_files` to determine which tests should run.