### PR TITLE
Add reminder comments about best practices for using secret keys

### DIFF
--- a/server/dotnet/Program.cs
+++ b/server/dotnet/Program.cs
@@ -4,8 +4,8 @@ using Stripe.Checkout;
 
 DotNetEnv.Env.Load();
 
-// Never put any keys in code! Always use a secrets vault or environment
-// variable to supply keys to your integration.
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
 //
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.

--- a/server/dotnet/Program.cs
+++ b/server/dotnet/Program.cs
@@ -4,6 +4,11 @@ using Stripe.Checkout;
 
 DotNetEnv.Env.Load();
 
+// Never put any keys in code! Always use a secrets vault or environment
+// variable to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
 
 StripeConfiguration.AppInfo = new AppInfo

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -25,6 +25,11 @@ func main() {
 	}
 	checkEnv()
 
+	// Never put any keys in code! Always use a secrets vault or environment
+	// variable to supply keys to your integration.
+	//
+	// See https://docs.stripe.com/keys-best-practices and find your
+	// keys at https://dashboard.stripe.com/apikeys.
 	stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
 
 	// For sample support and debugging, not required for production:

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -25,8 +25,8 @@ func main() {
 	}
 	checkEnv()
 
-	// Never put any keys in code! Always use a secrets vault or environment
-	// variable to supply keys to your integration.
+	// Don't put any keys in code. Use an environment variable (as shown
+	// here) or secrets vault to supply keys to your integration.
 	//
 	// See https://docs.stripe.com/keys-best-practices and find your
 	// keys at https://dashboard.stripe.com/apikeys.

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -43,6 +43,11 @@ public class Server {
 
         checkEnv();
 
+        // Never put any keys in code! Always use a secrets vault or environment
+        // variable to supply keys to your integration.
+        //
+        // See https://docs.stripe.com/keys-best-practices and find your
+        // keys at https://dashboard.stripe.com/apikeys.
         Stripe.apiKey = dotenv.get("STRIPE_SECRET_KEY");
         Stripe.setAppInfo(
             "stripe-samples/checkout-one-time-payments",

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -43,8 +43,8 @@ public class Server {
 
         checkEnv();
 
-        // Never put any keys in code! Always use a secrets vault or environment
-        // variable to supply keys to your integration.
+        // Don't put any keys in code. Use an environment variable (as shown
+        // here) or secrets vault to supply keys to your integration.
         //
         // See https://docs.stripe.com/keys-best-practices and find your
         // keys at https://dashboard.stripe.com/apikeys.

--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Never put any keys in code! Always use a secrets vault or environment
+// variable to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2025-12-15.clover",
   appInfo: {

--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -1,7 +1,7 @@
 import Stripe from "stripe";
 
-// Never put any keys in code! Always use a secrets vault or environment
-// variable to supply keys to your integration.
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
 //
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -7,6 +7,11 @@ require('dotenv').config({ path: './.env' });
 // Ensure environment variables are set.
 checkEnv();
 
+// Never put any keys in code! Always use a secrets vault or environment
+// variable to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -7,8 +7,8 @@ require('dotenv').config({ path: './.env' });
 // Ensure environment variables are set.
 checkEnv();
 
-// Never put any keys in code! Always use a secrets vault or environment
-// variable to supply keys to your integration.
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
 //
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -19,8 +19,8 @@ if (!$price || $price == 'price_12345') {
   "https://github.com/stripe-samples/checkout-one-time-payments"
 );
 
-// Never put any keys in code! Always use a secrets vault or environment
-// variable to supply keys to your integration.
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
 //
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -19,6 +19,11 @@ if (!$price || $price == 'price_12345') {
   "https://github.com/stripe-samples/checkout-one-time-payments"
 );
 
+// Never put any keys in code! Always use a secrets vault or environment
+// variable to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 \Stripe\Stripe::setApiKey($_ENV['STRIPE_SECRET_KEY']);
 
 if ($_SERVER['REQUEST_METHOD'] != 'POST') {

--- a/server/php/public/shared.php
+++ b/server/php/public/shared.php
@@ -27,8 +27,8 @@ if (!$price || $price == 'price_12345') {
   "https://github.com/stripe-samples/checkout-one-time-payments"
 );
 
-// Never put any keys in code! Always use a secrets vault or environment
-// variable to supply keys to your integration.
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
 //
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.

--- a/server/php/public/shared.php
+++ b/server/php/public/shared.php
@@ -27,6 +27,11 @@ if (!$price || $price == 'price_12345') {
   "https://github.com/stripe-samples/checkout-one-time-payments"
 );
 
+// Never put any keys in code! Always use a secrets vault or environment
+// variable to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 \Stripe\Stripe::setApiKey($config['stripe_secret_key']);
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -21,8 +21,9 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples/checkout-one-time-payments')
 
 stripe.api_version = '2020-08-27'
-# Never put any keys in code! Use a secrets vault or environment
-# variable to supply keys to your integration. 
+# Never put any keys in code! Always use a secrets vault or environment
+# variable to supply keys to your integration.
+#
 # See https://docs.stripe.com/keys-best-practices and find your
 # keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -21,6 +21,10 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples/checkout-one-time-payments')
 
 stripe.api_version = '2020-08-27'
+# Never put any keys in code! Use a secrets vault or environment
+# variable to supply keys to your integration. 
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -21,8 +21,8 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples/checkout-one-time-payments')
 
 stripe.api_version = '2020-08-27'
-# Never put any keys in code! Always use a secrets vault or environment
-# variable to supply keys to your integration.
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
 #
 # See https://docs.stripe.com/keys-best-practices and find your
 # keys at https://dashboard.stripe.com/apikeys.

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -19,6 +19,11 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples/checkout-one-time-payments'
 )
 Stripe.api_version = '2020-08-27'
+# Never put any keys in code! Always use a secrets vault or environment
+# variable to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -19,8 +19,8 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples/checkout-one-time-payments'
 )
 Stripe.api_version = '2020-08-27'
-# Never put any keys in code! Always use a secrets vault or environment
-# variable to supply keys to your integration.
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
 #
 # See https://docs.stripe.com/keys-best-practices and find your
 # keys at https://dashboard.stripe.com/apikeys.


### PR DESCRIPTION
At sites where secret keys are used, add a comment reminder about security best practices regarding key usages.