### PR TITLE
Unpin old API versions

### DIFF
--- a/server/node/server.js
+++ b/server/node/server.js
@@ -13,7 +13,6 @@ checkEnv();
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/checkout-one-time-payments",
     version: "0.0.1",

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -20,7 +20,6 @@ stripe.set_app_info(
     version='0.0.1',
     url='https://github.com/stripe-samples/checkout-one-time-payments')
 
-stripe.api_version = '2020-08-27'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -18,7 +18,6 @@ Stripe.set_app_info(
   version: '0.0.1',
   url: 'https://github.com/stripe-samples/checkout-one-time-payments'
 )
-Stripe.api_version = '2020-08-27'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #


### PR DESCRIPTION
Remove old API versions from Node, Python, and Ruby code examples. I verified that the code samples are still functional.