### PR TITLE
Align Stripe API version pins to 2026-07-29.dahlia

### DIFF
--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -6,7 +6,7 @@ import Stripe from "stripe";
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2025-12-15.clover",
+  apiVersion: "2026-07-29.dahlia",
   appInfo: {
     name: "stripe-samples/checkout-one-time-payments",
     version: "0.0.1",


### PR DESCRIPTION
## Summary
- Align explicit Stripe API version pins to **`2026-07-29.dahlia`** (latest GA default in `stripe@22.4.0`).
- Bump Node `stripe` dependency ranges to `^22.4.0` where package.json pins stripe.

## Evidence
- npm `stripe@22.4.0` → `ApiVersion = '2026-07-29.dahlia'`
- https://docs.stripe.com/upgrades

## Layerkit
Contract heal via layerkit agent pipeline (heal mode) + source-edit of production sample files.

## Test plan
- [ ] Spot-check PaymentIntent/Checkout Session create with test keys
- [ ] Confirm Dashboard request log shows Stripe-Version: 2026-07-29.dahlia
- [ ] CI sample suite if present